### PR TITLE
Add issue count, repo count and issue links to the github API

### DIFF
--- a/gitdash/pages/api/github.ts
+++ b/gitdash/pages/api/github.ts
@@ -11,8 +11,10 @@ export default async (req, res) => {
   const followers = await octokit.request(`/users/${username}/followers?per_page=100`)
   const followerCount = followers.data.length
 
-  // Number of stars
+  // Get all repos 
   const repos = await octokit.request(`/users/${username}/repos`);
+
+  // Number of stars
   const starsCount = repos.data.filter(repo => !repo.fork).reduce((acc, item) => {
       return acc + item.stargazers_count
   }, 0)
@@ -21,11 +23,36 @@ export default async (req, res) => {
   const reposStarred = await octokit.request(`/users/${username}/starred`)
   const starredCount = reposStarred.data.length
 
-  // List of repos
+  // Number of issues 
+  const issueCount = repos.data.filter(repo => !repo.fork).reduce((acc, item) => {
+    console.log(item.open_issues)
+    return acc + item.open_issues
+  }, 0)
+
+  // List of repos 
   const repo_names = repos.data.map(repo => repo.name)
 
-  // console.log(repos) - for API Testing 
+  // Number of repos
+  const num_repos = repo_names.length
+
+  /* Get the data related to the issues of a repository */ 
+  // Loop through the repo names 
+  const issueLinks = repos.data.map(repo => repo.issues_url.slice(0, -9))
+
+  // Note: Just getting the issue links right now but we can loop through 
+  // these and get data about all issues pertaining to public repos
+
+  // for API Testing 
+  console.log(repos) 
 
   // Return the counts
-  return res.status(200).json({ stars: starsCount, followers: followerCount, starred: starredCount, all_repos: repo_names})
+  return res.status(200).json({ 
+    stars: starsCount, 
+    followers: followerCount, 
+    starred: starredCount, 
+    all_repos: repo_names, 
+    repo_count: num_repos, 
+    issues: issueLinks, 
+    issue_count: issueCount 
+  })
 }


### PR DESCRIPTION
## What this does 

Extending the github API with the following information. 

- `stars`: Number of stars on your repos 
- `followers`: Number of followers 
- `starred`: Number of repos you have starred, 
- `all_repos`: Names of your repositories (array)
- `repo_count`: Number of repos you have 
- `issues`: Array of the links of all issues 
- `issue_count`: Number of issues on your repositories

![image](https://user-images.githubusercontent.com/38958532/127665736-b039874d-393e-4dc4-93b2-afed9aaeec0a.png)

This closes #16 