### PR TITLE
Refactor code from Octoki Rest to Octokit Core

### DIFF
--- a/gitdash/pages/api/github.ts
+++ b/gitdash/pages/api/github.ts
@@ -1,6 +1,6 @@
 import { getSession } from "next-auth/client";
 
-const { Octokit } = require("@octokit/rest");
+import { Octokit } from "@octokit/core";
 
 const secret = process.env.GITHUB_SECRET;
 
@@ -49,17 +49,17 @@ export default async function GetDetails(
 
   const octokit = new Octokit({
     auth: session?.accessToken,
-    // github token for a particular user, leaving empty for now
   });
 
   // Number of followers
   const followers = await octokit.request(
-    `/users/${username}/followers?per_page=100`
-  );
+    'GET /user/followers?per_page=100'
+  )
   const followerCount = followers.data.length;
 
   // Get all repos
-  const repos = await octokit.request(`/users/${username}/repos`);
+  const repos = await octokit.request('GET /user/repos?per_page=100&sort=updated')
+  console.log(repos)
 
   // Number of stars
   const starsCount = repos.data
@@ -69,7 +69,7 @@ export default async function GetDetails(
     }, 0);
 
   // Number of starred repos
-  const reposStarred = await octokit.request(`/users/${username}/starred`);
+  const reposStarred = await octokit.request('GET /user/starred?per_page=100');
   const starredCount = reposStarred.data.length;
 
   // Number of issues
@@ -91,12 +91,6 @@ export default async function GetDetails(
   const issueLinks = repos.data.map((repo: { issues_url: string | any[] }) =>
     repo.issues_url.slice(0, -9)
   );
-
-  // Note: Just getting the issue links right now but we can loop through
-  // these and get data about all issues pertaining to public repos
-
-  // for API Testing
-  // console.log(repos)
 
   // Return the counts
   return res.status(200).json({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
### Why This PR Adds Value

This PR changes API calls from Octokit Rest to Octokit core. 

@octokit/rest is redundant as @octokit/core has a lot more features and can do whatever @octokit/rest can do, but better.

### What This PR Adds

- Uninstalled octokit/rest.js library 
- Changed the code to use octokit core GET functions 

### Screenshot

![image](https://user-images.githubusercontent.com/38958532/127978111-c522c6bf-7bd5-4776-a798-9e4bab1a3f79.png)
![image](https://user-images.githubusercontent.com/38958532/127978151-d9c9ab13-66bc-4d0d-88b2-edc795a484ca.png)


### How This PR Could Be Improved

- Add more features 
### Issue This PR Closes

This closes #39 
