### PR TITLE
fix: removed the package-lock.json file from the root directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Just removed the package-lock.json file from the root directory of the repo. Get this merged ASAP, so we can move onto more important features