### PR TITLE
Create repo endpoints

### DIFF
--- a/gitdash/pages/api/all_repos.ts
+++ b/gitdash/pages/api/all_repos.ts
@@ -1,0 +1,47 @@
+import { getSession } from "next-auth/client";
+import { Octokit } from "@octokit/core";
+import parse from "parse-link-header";
+
+export default async function GetDetails(
+  req: any,
+  res: {
+    status: (arg0: number) => {
+      (): any;
+      new (): any;
+      json: {
+        (arg0: {
+          repoNames: any;
+          user: any;
+          repoCount: any; 
+        }): any;
+        new (): any;
+      };
+    };
+  }
+): Promise<any> {
+  const session = await getSession({ req });
+
+  const octokit = new Octokit({
+    auth: session?.accessToken,
+  });
+
+  // Get user data
+  const userData = await octokit.request("GET /user");
+  const username = userData.data.login
+
+  // Get all repos
+  const repos = await octokit.request("GET /user/repos");
+
+  // List of repos
+  const repo_names = repos.data.map((repo: { name: any }) => repo.name);
+
+  // Number of repos
+  const num_repos = repo_names.length;
+
+  // Return the data
+  return res.status(200).json({
+    user: username,
+    repoNames: repo_names,
+    repoCount: num_repos
+  });
+}

--- a/gitdash/pages/api/issues.ts
+++ b/gitdash/pages/api/issues.ts
@@ -25,7 +25,7 @@ export default async function GetIssueDetails(
 
   // Get all repos
   const repos = await octokit.request(
-    "GET /user/repos"
+    "GET /user/repos",
   );
 
   // Iterate through the repo names and collect the pull data
@@ -34,7 +34,7 @@ export default async function GetIssueDetails(
     if (repo.owner) {
       // Get issues data
       const assignedIssues = await octokit.request(
-        `GET /repos/{owner}/{repo}/issues?assignee=${userData.data.login}&sort=updated&per_page=1`,
+        `GET /repos/{owner}/{repo}/issues?sort=updated&per_page=100`,
         {
           owner: repo.owner.login,
           repo: repo.name,

--- a/gitdash/pages/api/single_repo.ts
+++ b/gitdash/pages/api/single_repo.ts
@@ -1,0 +1,110 @@
+import { getSession } from "next-auth/client";
+import { Octokit } from "@octokit/core";
+import parse from "parse-link-header";
+
+export default async function GetDetails(
+  req: any,
+  res: {
+    status: (arg0: number) => {
+      (): any;
+      new (): any;
+      json: {
+        (arg0: {
+          user: any; 
+          repoName: any;  
+          repoData: any; 
+          contributors: any; 
+          languages: any; 
+          tags: any; 
+          branches:any; 
+          commits: any; 
+          forks: any; 
+        }): any;
+        new (): any;
+      };
+    };
+  }
+): Promise<any> {
+  const session = await getSession({ req });
+
+  const octokit = new Octokit({
+    auth: session?.accessToken,
+  });
+
+  // Get user data
+  const userData = await octokit.request("GET /user");
+  const username = userData.data.login
+
+  // Repo name - to be set dynamically (or can be passed as a get request)
+  const repoName = 'intellimart' 
+
+  // Get the data about the spcific repo
+  const repoData = await octokit.request(
+    'GET /repos/{owner}/{repo}', 
+  {
+    owner: username,
+    repo: repoName
+  })
+
+  // Get repo contributors 
+  const contributors = await octokit.request(
+    'GET /repos/{owner}/{repo}/contributors', 
+  {
+    owner: username,
+    repo: repoName
+  })
+
+  // Get repo languages 
+  const languages = await octokit.request(
+    'GET /repos/{owner}/{repo}/languages', 
+  {
+    owner: username,
+    repo: repoName
+  })
+
+  // Get repo tags 
+  const tags = await octokit.request(
+    'GET /repos/{owner}/{repo}/tags', 
+  {
+    owner: username,
+    repo: repoName
+  })
+  
+  // Get a list of branches 
+  const branches = await octokit.request(
+    'GET /repos/{owner}/{repo}/branches', 
+  {
+    owner: username,
+    repo: repoName
+  })
+
+  // Get a list of commit data 
+  const commits = await octokit.request(
+    'GET /repos/{owner}/{repo}/commits?per_page=100', 
+  {
+    owner: username,
+    repo: repoName
+  })
+
+  // Get Forks 
+  const forks = await octokit.request(
+    'GET /repos/{owner}/{repo}/forks?per_page=100', 
+  {
+    owner: username,
+    repo: repoName
+  })
+
+
+  // Return the data
+  return res.status(200).json({
+    user: username,
+    repoName: repoName,
+    contributors: contributors.data, 
+    languages: languages.data, 
+    tags: tags.data,
+    branches: branches.data, 
+    commits: commits.data,
+    forks: forks.data,
+    repoData: repoData.data, 
+  });
+}


### PR DESCRIPTION
### Why This PR Adds Value

Creates endpoints for the data to be collected from different repos. 

### What This PR Adds

- The file `all_repos` generates a list of repositories for a user
- The file `single_repo` gets all the relevant data for a particular repository 

### Screenshot

Data returned for a particular repo

![image](https://user-images.githubusercontent.com/38958532/128378495-05d3ebb9-bd23-4013-95ee-e7c3bc265e9b.png)

### How This PR Could Be Improved

- The single repo endpoint can be fixed using a dynamic method for getting the repo name. The best method could be passing a GET request query as the repo_name but open to other methods. 
 
### Issue This PR Closes

This closes #55 
