### PR TITLE
Get private repo information

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ On creating the OAuth app on GitHub, you need to set the `GITHUB_ID` in the `.en
 
 ![GitHub OAuth App Creds](https://i.imgur.com/NurdT2w.png)
 
+After adding the GITHUB_ID and GITHUB_SECRET to your `.env` create two more values called `AUTH_SECRET` and `JWT_SECRET` which you can generate yourself as any 
+string which will be used to authenticate with Github.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.

--- a/gitdash/pages/api/auth/[...nextauth].ts
+++ b/gitdash/pages/api/auth/[...nextauth].ts
@@ -6,10 +6,18 @@ export default NextAuth({
     Providers.GitHub({
       clientId: process.env.GITHUB_ID,
       clientSecret: process.env.GITHUB_SECRET,
+      scope: "repo"
     }),
   ],
+  secret: process.env.AUTH_SECRET,
+  jwt: {
+    secret: process.env.JWT_SECRET,
+  },
 
   callbacks: {
+    async redirect(url, baseUrl) {
+      return "/dashboard";
+    },
     /**
      * @param  {object}  token     Decrypted JSON Web Token
      * @param  {object}  user      User object      (only available on sign in)
@@ -26,10 +34,8 @@ export default NextAuth({
     },
     async session(session, token) {
       // Add property to session, like an access_token from a provider.
-      session.accessToken = token.accessToken
-      return session
-    }
+      session.accessToken = token.accessToken;
+      return session;
+    },
   },
-
-
 });

--- a/gitdash/pages/login.tsx
+++ b/gitdash/pages/login.tsx
@@ -35,7 +35,7 @@ export default function Home() {
                 <Button
                   colorScheme="teal"
                   leftIcon={<FaGithub />}
-                  onClick={() => signIn("github", { callbackUrl: 'http://localhost:3000/dashboard' })}
+                  onClick={() => signIn("github")}
                 >
                   Sign in with GitHub
                 </Button>


### PR DESCRIPTION
### Why This PR Adds Value

This PR allows the application to get private repository information for the application. In order for this to be done a `AUTH_SECRET` and `JWT_SECRET` need to be added to the `.env` to allow scopes to be added to the authentication process to allow the application to fetch user private repositories.

### What This PR Adds

- Get Private Repos
- Add new requirements to the README

### Screenshot

![Log Of Info](https://user-images.githubusercontent.com/39209557/128431147-5088af56-9116-42b3-bce6-b355f7632acc.PNG)
![Asking User for Private repo info](https://user-images.githubusercontent.com/39209557/128431278-fd35d930-e813-42f7-8585-2506683a1d91.PNG)

### Issue This PR Closes

This closes #57 
