### PR TITLE
feat: changed the background color of the team section on the home page

### DIFF
--- a/gitdash/components/team.tsx
+++ b/gitdash/components/team.tsx
@@ -89,7 +89,7 @@ const TeamAvatar = ({
 
 export default function TeamSection() {
   return (
-    <Box bg={useColorModeValue("gray.100", "gray.700")}>
+    <Box>
       <Container maxW={"7xl"} py={16} as={Stack} spacing={12}>
         <Stack spacing={0} align={"center"}>
           <Heading>The Team</Heading>


### PR DESCRIPTION
### Why This PR Adds Value
The lighter color of the team section on the home page stuck out like a sore thumb

### What This PR Adds
- Changes the background color of the team section on the home page to be more consistent with the rest of the home page design
